### PR TITLE
Deleted Run as admin escalation line and replaced with #requires

### DIFF
--- a/Scripts/New-VMs.ps1
+++ b/Scripts/New-VMs.ps1
@@ -1,6 +1,7 @@
 # Create VMs
 # Creates Hyper-V VM's with specific settings for College Class Labs.
 # Joseph Wahba
+#Requires -RunAsAdministrator
 param (
     $VMPath = "$($HOME)\Documents\HyperVM\",
     $VMVHD = "$($HOME)\Documents\HyperVM\",
@@ -8,8 +9,6 @@ param (
     $VNet = "Default Switch",
     $VNetType
 )
-
-if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) { Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs; exit }
 
 $VMname = Read-Host "Enter VM Name, Type end to end"
 if ($VNet -ne "Default Switch") {


### PR DESCRIPTION
Originally had auto privilege escalation to make it easier as hyperv commands needed admin, but it didn't work and is now replaced with a #Requires statement.